### PR TITLE
Add ZEISS Digital Innovation featured links

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -351,6 +351,75 @@ nav ul.nav-links li a:focus-visible::after {
   margin-top: 16px;
 }
 
+.feature-item.feature-links {
+  text-align: left;
+}
+
+.feature-subheadline {
+  color: rgba(255, 255, 255, 0.82);
+  max-width: 760px;
+  margin: 0 auto 32px auto;
+  text-align: center;
+}
+
+.feature-links-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.feature-link-card {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 18px 22px;
+  border-radius: 18px;
+  background: rgba(12, 12, 12, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 12px 24px rgba(0, 0, 0, 0.45);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.feature-link-card:hover,
+.feature-link-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 100, 0, 0.45);
+  box-shadow: 0 18px 36px rgba(255, 100, 0, 0.16);
+}
+
+.feature-link-icon {
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, rgba(255, 100, 0, 0.32), rgba(255, 100, 0, 0.08));
+  color: var(--accent-color);
+}
+
+.feature-link-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.feature-link-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.feature-link-title {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  color: var(--secondary-color);
+}
+
+.feature-link-description {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+}
+
 .btn,
 .btn_discover,
 .btn_pong,

--- a/index.html
+++ b/index.html
@@ -65,6 +65,64 @@
         <a class="btn" href="Files/Cosmic Voyager_ A Game Design Journey_fin.wav">Get the Summary</a>
         <a class="btn" href="Files/AI-Powered Web Game Development_DRL focis.wav">Get the Deep Dive</a>
       </div>
+      <div class="feature-item feature-links">
+        <h3>ZEISS Digital Innovation links to my work on research, AI-based solutions, medical cloud platforms, and broader digital solutions.</h3>
+        <p class="feature-subheadline">Feel free to click on these links to discover content like whitepapers and webinars that I have created with my team. Feel free to reach out to discuss any of these topics.</p>
+        <div class="feature-links-grid">
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/insights/v/patient-and-clinician-empowerment.html" target="_blank" rel="noopener">
+            <span class="feature-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <path fill="currentColor" d="M11 6h2v5h5v2h-5v5h-2v-5H6v-2h5z"></path>
+              </svg>
+            </span>
+            <span class="feature-link-text">
+              <span class="feature-link-title">Patient &amp; Clinician Empowerment</span>
+              <span class="feature-link-description">Human-centered research and co-creation to elevate digital health journeys.</span>
+            </span>
+          </a>
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/insights/a/semeco.html" target="_blank" rel="noopener">
+            <span class="feature-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <path fill="currentColor" d="M12 6l3.5 2v4L12 14l-3.5-2V8z"></path>
+                <path fill="currentColor" d="M7 15h10v2H7z"></path>
+              </svg>
+            </span>
+            <span class="feature-link-text">
+              <span class="feature-link-title">Semeco – Secure Medical Cooperation</span>
+              <span class="feature-link-description">Collaborative ecosystem work shaping secure, connected medical platforms.</span>
+            </span>
+          </a>
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/insights/w/ehds-medtech.html" target="_blank" rel="noopener">
+            <span class="feature-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <path fill="currentColor" d="M7 9h10v2H7z"></path>
+                <path fill="currentColor" d="M9 13h6v2H9z"></path>
+                <path fill="currentColor" d="M12 5l5 4H7z"></path>
+              </svg>
+            </span>
+            <span class="feature-link-text">
+              <span class="feature-link-title">EHDS for MedTech</span>
+              <span class="feature-link-description">Insights on European Health Data Space readiness for MedTech innovators.</span>
+            </span>
+          </a>
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/expertise/genai.html" target="_blank" rel="noopener">
+            <span class="feature-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <path fill="currentColor" d="M12 7a5 5 0 1 1-5 5 5 5 0 0 1 5-5zm0 2a3 3 0 1 0 3 3 3 3 0 0 0-3-3z"></path>
+                <path fill="currentColor" d="M5.5 18.5l2.12-2.12 1.41 1.41L6.91 19.9zM18.5 5.5l-2.12 2.12-1.41-1.41L17.09 4.1z"></path>
+              </svg>
+            </span>
+            <span class="feature-link-text">
+              <span class="feature-link-title">Generative AI Expertise</span>
+              <span class="feature-link-description">Applied GenAI accelerators and solution blueprints for cloud-native delivery.</span>
+            </span>
+          </a>
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add ZEISS Digital Innovation spotlight section to the featured content area with descriptive copy and external resources
- style the new featured link cards with responsive layout, hover states, and custom SVG icons

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106c128fe0832db118c72ca3fa124b)