### PR TITLE
Adjust featured section layout

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -331,6 +331,10 @@ nav ul.nav-links li a:focus-visible::after {
   text-align: center;
 }
 
+.feature-item + .feature-item {
+  margin-top: 48px;
+}
+
 .feature-item h3 {
   margin-bottom: 18px;
   color: var(--secondary-color);
@@ -365,7 +369,7 @@ nav ul.nav-links li a:focus-visible::after {
 .feature-links-grid {
   display: grid;
   gap: 20px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .feature-link-card {
@@ -418,6 +422,12 @@ nav ul.nav-links li a:focus-visible::after {
 .feature-link-description {
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.78);
+}
+
+@media (max-width: 820px) {
+  .feature-links-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .btn,


### PR DESCRIPTION
## Summary
- increase spacing between the featured content cards to prevent visual overlap
- constrain the Discover grid to two columns and collapse to one column on smaller screens

## Testing
- No tests were run (not recommended)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910724cba78832d90b422d035b11571)