### PR TITLE
Ensure uniform desktop startup card heights

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -611,6 +611,20 @@ nav ul.nav-links li a:focus-visible::after {
   object-fit: contain;
 }
 
+@media (min-width: 981px) {
+  .startup-grid {
+    align-items: stretch;
+  }
+
+  .startup-item {
+    height: 100%;
+  }
+
+  .startup-item .btn_discover {
+    margin-top: auto;
+  }
+}
+
 .work-experience .job-item,
 .education .edu-item,
 .research .res-item {


### PR DESCRIPTION
## Summary
- stretch startup grid cards on desktop so each column aligns to a consistent height
- anchor the discover button to the bottom of each startup card to preserve layout balance

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691093be797c832db8128417d671afc7)