### PR TITLE
Add featured white paper bucket to Featured Content

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -361,6 +361,10 @@ nav ul.nav-links li a:focus-visible::after {
   text-align: left;
 }
 
+.feature-item.feature-whitepaper {
+  text-align: center;
+}
+
 .feature-subheadline {
   color: rgba(255, 255, 255, 0.82);
   max-width: 760px;
@@ -424,6 +428,32 @@ nav ul.nav-links li a:focus-visible::after {
 .feature-link-description {
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.78);
+}
+
+.feature-visual-card {
+  display: block;
+  max-width: 420px;
+  margin: 0 auto;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(12, 12, 12, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 12px 24px rgba(0, 0, 0, 0.45);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.feature-visual-card img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 14px;
+}
+
+.feature-visual-card:hover,
+.feature-visual-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(255, 100, 0, 0.45);
+  box-shadow: 0 18px 36px rgba(255, 100, 0, 0.16);
 }
 
 @media (max-width: 820px) {

--- a/index.html
+++ b/index.html
@@ -334,6 +334,12 @@
           </a>
         </div>
       </div>
+      <div class="feature-item feature-whitepaper">
+        <h3>Selected content pieces from my work.</h3>
+        <a class="feature-visual-card" href="https://www.zeiss.com/content/dam/zdi/health-solution/downloads/zeiss-digital-innovation_whitepaper_building_tomorrows_healthcare_platform.pdf" target="_blank" rel="noopener" aria-label="Read the white paper Building Tomorrow's Healthcare Platform, Compliant and Built to Scale">
+          <img src="Images/SEMECO_Cloud_Platform.png" alt="Cover of the white paper Building Tomorrow's Healthcare Platform, Compliant and Built to Scale">
+        </a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Introduce a third bucket in the Featured Content section to surface main content pieces such as white papers. 
- Provide a clickable cover image that forwards users to the white paper PDF `Building Tomorrow's Healthcare Platform, Compliant and Built to Scale`.
- Keep the visual behavior consistent with the existing ZEISS feature cards by reusing the same hover/animation affordance. 

### Description
- Added a new block in `index.html`: a `div` with `class="feature-item feature-whitepaper"` containing a headline and an anchor linking to the white paper PDF and displaying `Images/SEMECO_Cloud_Platform.png` as the cover. 
- Implemented a visual card component `feature-visual-card` and added styles for `.feature-item.feature-whitepaper` in `CSS/Styles.css`. 
- The new CSS mirrors the existing `.feature-link-card` transitions and hover effect to provide a consistent `translateY(-4px)` lift and accent border/shadow. 

### Testing
- Served the site locally with `python -m http.server 8000` and validated the page render via a Playwright script which captured `artifacts/feature-whitepaper.png`. The screenshot generation succeeded. 
- Static style checks were validated by inspecting `CSS/Styles.css` rules applied to the new card and feature item, and no runtime errors occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694672279c28832da3bf2225e601a6e7)