### PR TITLE
Remove duplicate featured section, add 2‑column visual grid, and fix whitepaper link

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -430,6 +430,14 @@ nav ul.nav-links li a:focus-visible::after {
   color: rgba(255, 255, 255, 0.78);
 }
 
+.feature-visual-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  justify-items: center;
+}
+
 .feature-visual-card {
   display: block;
   max-width: 420px;

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
               <span class="feature-link-description">Our approach for enabling secure and compliant cloud adoption from assessment through migration, platform build-out, scaling and operations.</span>
             </span>
           </a>
-          <a class="feature-link-card" href="#" aria-label="Read the white paper on digital health apps in the hospital of the future">
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/insights/w/whitepaper-dtx.html" target="_blank" rel="noopener" aria-label="Read the white paper on digital health apps in the hospital of the future">
             <span class="feature-link-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" role="presentation" focusable="false">
                 <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
@@ -359,12 +359,6 @@
             <img src="Images/GenAIWebinar.png" alt="Cover image for the Generative AI webinar">
           </a>
         </div>
-      </div>
-      <div class="feature-item feature-whitepaper">
-        <h3>Selected content pieces from my work.</h3>
-        <a class="feature-visual-card" href="https://www.zeiss.com/content/dam/zdi/health-solution/downloads/zeiss-digital-innovation_whitepaper_building_tomorrows_healthcare_platform.pdf" target="_blank" rel="noopener" aria-label="Read the white paper Building Tomorrow's Healthcare Platform, Compliant and Built to Scale">
-          <img src="Images/SEMECO_Cloud_Platform.png" alt="Cover of the white paper Building Tomorrow's Healthcare Platform, Compliant and Built to Scale">
-        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
### Motivation
- Remove a duplicate single-item featured content block so only the intended container remains. 
- Present the two visual items in the featured container horizontally in two columns instead of stacked vertically. 
- Ensure the "From Hype to Value: Digital Health Apps" item links to the correct destination. 

### Description
- Updated `index.html` to set the whitepaper anchor `href` to `https://www.zeiss.com/digital-innovation/insights/w/whitepaper-dtx.html` and added `target="_blank" rel="noopener"` for the external link. 
- Removed the duplicate bottom `.feature-item.feature-whitepaper` block from `index.html`. 
- Added a new `.feature-visual-grid` rule in `CSS/Styles.css` that uses `display: grid` with `grid-template-columns: repeat(2, minmax(0, 1fr))` and gap/alignment settings to produce a two-column layout. 
- Kept responsive behavior via the existing media query so the grid collapses to one column on narrow viewports. 

### Testing
- Launched a local server with `python -m http.server 8000` and rendered `index.html` using a Playwright script which captured `artifacts/featured-content.png`, and the rendering run completed successfully. 
- Verified the repository changes with `git show --stat` after committing the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469cab17e4832da9725447cf081019)