### PR TITLE
Add AI Readiness Check to Featured Content

### DIFF
--- a/index.html
+++ b/index.html
@@ -345,6 +345,18 @@
               <span class="feature-link-description">Whitepaper on the state of digital health apps and therapeutics, with practical guidance for MedTech adoption in the hospital of the future.</span>
             </span>
           </a>
+          <a class="feature-link-card" href="https://www.zeiss.com/digital-innovation/insights/o/ai-readiness-check.html" target="_blank" rel="noopener">
+            <span class="feature-link-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" role="presentation" focusable="false">
+                <circle cx="12" cy="12" r="11" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                <path fill="currentColor" d="M8 12l2.5 2.5L16 9l1.5 1.5L10.5 17 6.5 13z"></path>
+              </svg>
+            </span>
+            <span class="feature-link-text">
+              <span class="feature-link-title">AI Readiness Check</span>
+              <span class="feature-link-description">Quick assessment to gauge AI maturity and identify next steps across strategy, data, and governance.</span>
+            </span>
+          </a>
         </div>
       </div>
       <div class="feature-item feature-whitepaper">


### PR DESCRIPTION
### Motivation
- Add an additional item to the "Discover public parts of my work at ZEISS Digital Innovation" featured links to surface the AI Readiness Check resource.
- Keep the new entry concise and consistent with the existing featured link cards in headline and description.

### Description
- Updated `index.html` to insert a new `feature-link-card` pointing to `https://www.zeiss.com/digital-innovation/insights/o/ai-readiness-check.html` with the title `AI Readiness Check` and a short description summarizing assessment across strategy, data, and governance.
- Included a simple inline SVG icon for the new card and placed it alongside the other featured link cards in the existing grid.

### Testing
- Launched a local server with `python -m http.server` and captured a full-page screenshot using Playwright saved at `artifacts/featured-content.png`, which completed successfully after one retry.
- No unit tests were applicable for this static HTML change and no other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d50a44b8c832dba0b8286bba8d1a3)