### PR TITLE
Update featured content to add video CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,10 +245,10 @@
     <div class="container">
       <h2>Featured Content</h2>
       <div class="feature-item">
-        <h3>Listen to podcasts on the creation of my web game "Cosmic Voyager" including an AI-powered backend.</h3>
-        <p>Listen to the podcast summarizing the key points or the one with a deeper focus on the AI model development. You can also read the referenced reports below.</p>
+        <h3>Listen to the podcast or watch the video on the creation of my web game "Cosmic Voyager," including an AI-powered backend.</h3>
+        <p>Listen to the podcast or watch the video summarizing the key points from building Cosmic Voyager, and explore the referenced reports below.</p>
         <a class="btn" href="Files/Cosmic Voyager_ A Game Design Journey_fin.wav">Get the Summary</a>
-        <a class="btn" href="Files/AI-Powered Web Game Development_DRL focis.wav">Get the Deep Dive</a>
+        <a class="btn" href="https://drive.google.com/file/d/10xvHe88rYnMIcq4y6RrHJugrZqzSYhDI/view?usp=sharing">Watch the Video</a>
       </div>
       <div class="feature-item feature-links">
         <h3>Discover public parts of my work at ZEISS Digital Innovation including research, AI-based solutions, and medical cloud platforms.</h3>


### PR DESCRIPTION
### Motivation
- Announce both the podcast and a new video for the Cosmic Voyager story and replace the previous "deep dive" CTA with a direct video link for easier access.

### Description
- Updated `index.html` to change the featured headline and subheadline to mention "Listen to the podcast or watch the video", and replaced the second CTA with a `Watch the Video` button linking to `https://drive.google.com/file/d/10xvHe88rYnMIcq4y6RrHJugrZqzSYhDI/view?usp=sharing`.

### Testing
- No automated test suite was run; a local visual check was attempted by serving with `python -m http.server` and taking a screenshot via Playwright but the Playwright run timed out and the visual check did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696caf462324832db3ae63a2902a34d7)