### PR TITLE
Add embedded profile video section

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -333,6 +333,34 @@ nav ul.nav-links li a:focus-visible::after {
   text-align: center;
 }
 
+.profile-video-card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 40px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.profile-video-card p {
+  color: rgba(255, 255, 255, 0.9);
+  max-width: 720px;
+  margin: 0 auto 28px;
+}
+
+.profile-video-frame {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.profile-video-frame video {
+  width: min(860px, 100%);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.55);
+}
+
 .feature-item + .feature-item {
   margin-top: 48px;
 }

--- a/index.html
+++ b/index.html
@@ -241,6 +241,21 @@
     </div>
   </section>
 
+  <section id="profile-video" class="profile-video section-card" data-animate="fade-up">
+    <div class="container">
+      <h2>Watch my five-minute profile video</h2>
+      <div class="profile-video-card">
+        <p>Get a quick, five-minute overview of my background, focus areas, and current work.</p>
+        <div class="profile-video-frame">
+          <video controls playsinline preload="metadata">
+            <source src="Files/Profile_AndreasT__bachmeier.mp4" type="video/mp4">
+            Your browser does not support the video tag.
+          </video>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section id="feature" class="feature section-card" data-animate="fade-up">
     <div class="container">
       <h2>Featured Content</h2>


### PR DESCRIPTION
### Motivation
- Provide a new, self-contained section on the homepage that embeds the personal profile video so visitors can watch it inline without leaving the site.
- Keep the look and feel consistent with other site sections and enable native playback controls (play/pause, fullscreen, browser playback-rate options).

### Description
- Inserted a new `<section id="profile-video" ...>` in `index.html` with the headline `Watch my five-minute profile video` and an HTML5 `<video>` element sourcing `Files/Profile_AndreasT__bachmeier.mp4` and using `controls playsinline preload="metadata"`.
- Added `.profile-video-card`, `.profile-video-frame`, and `.profile-video-frame video` styles to `CSS/Styles.css` to match existing section-card aesthetics and constrain the player width.
- Section placed directly beneath the hero area so it appears before the existing Featured Content section.

### Testing
- Served the site locally with `python -m http.server 8000` and verified the page loads successfully in a headless browser.
- Ran a Playwright script to open `http://127.0.0.1:8000/index.html` and capture a screenshot saved as `artifacts/profile-video-section.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cbcea120c832d9926517a23b75b23)