### PR TITLE
Fix profile video source filename in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
         <p>Get a quick, five-minute overview of my background, focus areas, and current work.</p>
         <div class="profile-video-frame">
           <video controls playsinline preload="metadata">
-            <source src="Files/Profile_AndreasT__bachmeier.mp4" type="video/mp4">
+            <source src="Files/Profile_Andreas_T_Bachmeier.mp4" type="video/mp4">
             Your browser does not support the video tag.
           </video>
         </div>


### PR DESCRIPTION
### Motivation
- Ensure the embedded profile video player loads the actual MP4 file so the video is playable on the page.

### Description
- Updated `index.html` video source from `Files/Profile_AndreasT__bachmeier.mp4` to `Files/Profile_Andreas_T_Bachmeier.mp4` so the `<video>` tag points to the existing file.

### Testing
- Served the site locally with `python -m http.server` which started successfully, and attempted an automated Playwright screenshot that timed out (Playwright run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cc4458a5c832d86a7b990030c436e)