### PR TITLE
Update profile video section copy and thumbnail link

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,14 +243,13 @@
 
   <section id="profile-video" class="profile-video section-card" data-animate="fade-up">
     <div class="container">
-      <h2>Watch my five-minute profile video</h2>
+      <h2>Watch my profile video</h2>
       <div class="profile-video-card">
-        <p>Get a quick, five-minute overview of my background, focus areas, and current work.</p>
+        <p>Get a quick 15-minute overview of my background, focus area, and current work.</p>
         <div class="profile-video-frame">
-          <video controls playsinline preload="metadata">
-            <source src="Files/Profile_Andreas_T_Bachmeier.mp4" type="video/mp4">
-            Your browser does not support the video tag.
-          </video>
+          <a href="https://drive.google.com/file/d/1FWwELgP3nPy89AvzNqVTPjSVXqLa_Mbl/view?usp=sharing" target="_blank" rel="noopener">
+            <img src="Images/Profile_Video_Thumbnail.png" alt="Profile video thumbnail">
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Simplify the profile video headline by removing the runtime specification and update the subheadline to advertise a 15-minute overview.
- Replace the embedded video with a linked thumbnail so the site links to the externally hosted video instead of streaming it from the site.

### Description
- Changed the section heading from "Watch my five-minute profile video" to "Watch my profile video" in `index.html`.
- Updated the subheadline copy to `Get a quick 15-minute overview of my background, focus area, and current work.` in `index.html`.
- Removed the embedded `<video>` element and replaced it with an anchor to the Google Drive video (`https://drive.google.com/file/d/1FWwELgP3nPy89AvzNqVTPjSVXqLa_Mbl/view?usp=sharing`) that wraps the thumbnail image `Images/Profile_Video_Thumbnail.png` and includes `target="_blank" rel="noopener"`.
- Committed the change with the message `Update profile video section` affecting `index.html`.

### Testing
- Started a local server with `python -m http.server 8000` to serve the site; the server launched but was interrupted by the session (no full visual verification completed).
- Attempted to capture a screenshot using Playwright to verify the updated section, but the Playwright run timed out and the screenshot step failed.
- No automated unit tests were run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e975a622c832d8d97b3e6f511471d)