### PR TITLE
Embed YouTube video in profile section

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,9 +247,7 @@
       <div class="profile-video-card">
         <p>Get a quick 15-minute overview of my background, focus area, and current work.</p>
         <div class="profile-video-frame">
-          <a href="https://drive.google.com/file/d/1FWwELgP3nPy89AvzNqVTPjSVXqLa_Mbl/view?usp=sharing" target="_blank" rel="noopener">
-            <img src="Images/Profile_Video_Thumbnail.png" alt="Profile video thumbnail">
-          </a>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/hvVaL33SOfU?si=-ghDOdOMJIM3TiwZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Replace the external Google Drive thumbnail/link with an embedded YouTube player so visitors can watch the profile video directly on the site.

### Description
- Updated `index.html` to replace the anchor and thumbnail in the `#profile-video` section with the provided YouTube `<iframe>` embed (`src="https://www.youtube.com/embed/hvVaL33SOfU?si=-ghDOdOMJIM3TiwZ"`).

### Testing
- Served the site locally with `python -m http.server 8000` to confirm the page is reachable and the change is present.
- Attempted a headless browser screenshot with Playwright to validate rendering, but the Playwright run timed out and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9b1f6320832d806fa319bb04b9c5)