### PR TITLE
Make profile video iframe fill card width and be responsive

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -354,8 +354,11 @@ nav ul.nav-links li a:focus-visible::after {
   align-items: center;
 }
 
-.profile-video-frame video {
-  width: min(860px, 100%);
+.profile-video-frame video,
+.profile-video-frame .profile-video-embed {
+  width: min(980px, 100%);
+  aspect-ratio: 16 / 9;
+  height: auto;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: 0 24px 50px rgba(0, 0, 0, 0.55);

--- a/index.html
+++ b/index.html
@@ -247,9 +247,7 @@
       <div class="profile-video-card">
         <p>Get a quick 15-minute overview of my background, focus area, and current work.</p>
         <div class="profile-video-frame">
-          <a href="https://drive.google.com/file/d/1FWwELgP3nPy89AvzNqVTPjSVXqLa_Mbl/view?usp=sharing" target="_blank" rel="noopener">
-            <img src="Images/Profile_Video_Thumbnail.png" alt="Profile video thumbnail">
-          </a>
+          <iframe class="profile-video-embed" src="https://www.youtube.com/embed/hvVaL33SOfU?si=-ghDOdOMJIM3TiwZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- The embedded YouTube iframe in the "Watch my profile video" card was too small and should expand to nearly the full width of its enclosing container and resize correctly on smaller screens.

### Description
- Replaced the Drive thumbnail anchor with a YouTube `<iframe>` that uses the class `profile-video-embed` in `index.html`.
- Added CSS to target `.profile-video-frame .profile-video-embed` (and existing `video`) to use `width: min(980px, 100%)`, `aspect-ratio: 16 / 9`, and `height: auto` so the embed scales responsively while keeping the existing border-radius, border, and shadow.
- Kept the iframe centered using the existing `.profile-video-frame` flex container.

### Testing
- Served the site locally with `python -m http.server 8000` to confirm the page is reachable (succeeded). 
- Ran a Playwright screenshot script to validate rendering, but the Playwright run timed out and did not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9b1f6320832d806fa319bb04b9c5)