### PR TITLE
Add GenAI whitepaper to Selected content and display three cards horizontally

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -464,7 +464,7 @@ nav ul.nav-links li a:focus-visible::after {
 .feature-visual-grid {
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: start;
   justify-items: center;
 }

--- a/index.html
+++ b/index.html
@@ -382,6 +382,10 @@
             <span class="feature-visual-title">Webinar</span>
             <img src="Images/GenAIWebinar.png" alt="Cover image for the Generative AI webinar">
           </a>
+          <a class="feature-visual-card" href="https://www.zeiss.com/digital-innovation/insights/w/wp-genai.html" target="_blank" rel="noopener" aria-label="Read the whitepaper on Generative AI">
+            <span class="feature-visual-title">Whitepaper</span>
+            <img src="Images/GenAI_whitepaper.png" alt="Cover image for the Generative AI whitepaper">
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- The Selected content section showed only two visual items (one whitepaper and one webinar), and a second whitepaper should be added so the three items appear side-by-side on desktop.

### Description
- Added a new `feature-visual-card` in `index.html` linking to `https://www.zeiss.com/digital-innovation/insights/w/wp-genai.html` and using the existing `Images/GenAI_whitepaper.png` as the cover image.
- Updated `CSS/Styles.css` to change `.feature-visual-grid` to `grid-template-columns: repeat(3, minmax(0, 1fr));` so the three cards align horizontally on larger screens.
- Kept responsive behavior intact so the grid collapses to a single column below the existing `820px` breakpoint.

### Testing
- Verified the code changes with `git diff` to ensure only `index.html` and `CSS/Styles.css` were modified and the new card was added (success).
- Served the site locally with `python -m http.server 8000` and captured a screenshot via Playwright to visually confirm three horizontally aligned items (success).
- Confirmed the cover image `Images/GenAI_whitepaper.png` exists in the repository (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69903bd39134832db6627adfa87a84a1)