### PR TITLE
Mark PlainHive, INSPYRALL, and fibulaXpand as discontinued and update footer year to 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,12 +482,12 @@
         </div>
         <div class="startup-item" id="plainhive" data-animate="fade-up">
           <div class="logo"><img src="Images/Logo_Text_PlainHive_white_.png" alt="PlainHive Logo"></div>
-          <p>PlainHive is a transparent, multi-agent AI system designed to collaborate with you — it works alongside you, rather than replacing you, by orchestrating multiple intelligent agents that reason, assist, and automate tasks while maintaining explainability and trust.</p>
+          <p>Discontinued: I am currently not working on this project anymore. PlainHive is a transparent, multi-agent AI system designed to collaborate with you — it works alongside you, rather than replacing you, by orchestrating multiple intelligent agents that reason, assist, and automate tasks while maintaining explainability and trust.</p>
           <a class="btn_discover" href="https://andreas-t-bachmeier-bantho.github.io/plainhive/" target="_blank">Discover PlainHive</a>
         </div>
         <div class="startup-item" id="inspyrall" data-animate="fade-up">
           <div class="logo"><img src="Images/INSPYRALL_Logo.png" alt="Inspyrall Logo"></div>
-          <p>INSPYRALL is an AI-powered inspiration & news platform where personalized insights and inspiration come together to help users save time, stay informed, and expand their knowledge effortlessly.</p>
+          <p>Discontinued: I am currently not working on this project anymore. INSPYRALL is an AI-powered inspiration & news platform where personalized insights and inspiration come together to help users save time, stay informed, and expand their knowledge effortlessly.</p>
           <a class="btn_discover" href="https://inspyrall.uwu.ai/" target="_blank">Discover INSPYRALL</a>
         </div>
         <div class="startup-item" id="bantho" data-animate="fade-up">
@@ -497,7 +497,7 @@
         </div>
         <div class="startup-item" id="fibulaxpand" data-animate="fade-up">
           <div class="logo"><img src="Images/Logo_fibulaXpand_v2_cut2-modified-gray.png" alt="fibulaXpand Logo"></div>
-          <p>fibulaXpand is a groundbreaking approach to repair severely injured limbs saving them from amputation. Our innovative system enlarges the diameter of a bone and grows an autologous bone graft within the patient's leg enabling a faster recovery and return to daily activities.</p>
+          <p>Discontinued: I am currently not working on this project anymore. fibulaXpand is a groundbreaking approach to repair severely injured limbs saving them from amputation. Our innovative system enlarges the diameter of a bone and grows an autologous bone graft within the patient's leg enabling a faster recovery and return to daily activities.</p>
           <a class="btn_discover" href="fibulaXpand.html" target="_blank">Discover fibulaXpand</a>
         </div>
       </div>
@@ -710,7 +710,7 @@
     </div>
 
     <div class="footer-credits">
-      <p>© 2025 – Dr. Andreas T. Bachmeier</p>
+      <p>© 2026 – Dr. Andreas T. Bachmeier</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
### Motivation
- Clarify on the main site that several past startups are no longer active and update the site copyright year to the current year.

### Description
- Prepended "Discontinued: I am currently not working on this project anymore." to the startup descriptions for `PlainHive`, `INSPYRALL`, and `fibulaXpand` in `index.html`, and updated the footer from `© 2025` to `© 2026`.

### Testing
- Verified the changes by searching `index.html` with `rg -n "Discontinued: I am currently not working on this project anymore|© 2026" index.html` and inspected the modified lines with `nl -ba index.html | sed -n '478,506p;708,716p'`, both confirming the expected updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9fd571d7c832dbe013073c924b0d1)