### PR TITLE
Add public speaker cards, header nav link, and reduce header/logo size

### DIFF
--- a/CSS/Styles.css
+++ b/CSS/Styles.css
@@ -118,14 +118,14 @@ header .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 32px;
+  gap: 24px;
   width: 100%;
   margin: 0;
-  padding: 18px 28px;
+  padding: 12px 24px;
 }
 
 .logo img {
-  width: 78px;
+  width: 51px;
   transition: transform var(--transition-base), filter var(--transition-base);
   filter: drop-shadow(0 12px 20px rgba(0, 0, 0, 0.4));
 }
@@ -144,13 +144,13 @@ nav ul.nav-links {
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 28px;
+  gap: 22px;
 }
 
 nav ul.nav-links li a {
   position: relative;
   color: var(--secondary-color);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 500;
   letter-spacing: 0.04em;
   padding: 6px 0;
@@ -481,11 +481,42 @@ nav ul.nav-links li a:focus-visible::after {
   transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
 }
 
+.feature-visual-title {
+  display: block;
+  margin-bottom: 14px;
+  color: var(--secondary-color);
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
 .feature-visual-card img {
   width: 100%;
   height: auto;
   display: block;
   border-radius: 14px;
+}
+
+.feature-speaker {
+  text-align: center;
+}
+
+.feature-speaker-grid {
+  grid-template-columns: repeat(2, minmax(0, 320px));
+  justify-content: center;
+}
+
+.feature-speaker-card {
+  width: 100%;
+  max-width: 320px;
+}
+
+.feature-speaker-card img {
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
 }
 
 .feature-visual-card:hover,
@@ -906,7 +937,7 @@ footer .contact-list li img:hover {
   }
 
   header .container {
-    padding: 16px 24px;
+    padding: 12px 20px;
   }
 
   main {
@@ -978,7 +1009,7 @@ footer .contact-list li img:hover {
   }
 
   .logo img {
-    width: 64px;
+    width: 42px;
   }
 
   main {
@@ -1027,7 +1058,7 @@ footer .contact-list li img:hover {
   }
 
   .logo img {
-    width: 52px;
+    width: 34px;
   }
 
   nav ul.nav-links {

--- a/index.html
+++ b/index.html
@@ -209,6 +209,7 @@
       <a href="index.html" class="logo"><img src="Images/LogoATB_white.png" alt="Logo"></a>
       <nav>
         <ul class="nav-links">
+          <li><a href="#feature">Featured Content</a></li>
           <li><a href="#projects">Projects</a></li>          
           <li><a href="#startups">Startups</a></li>
           <li><a href="#experience">Experience</a></li>
@@ -386,6 +387,19 @@
             <span class="feature-visual-title">Whitepaper</span>
             <img src="Images/GenAI_whitepaper.png" alt="Cover image for the Generative AI whitepaper">
           </a>
+        </div>
+      </div>
+      <div class="feature-item feature-speaker">
+        <h3>Examples of my appearances as public speaker.</h3>
+        <div class="feature-visual-grid feature-speaker-grid">
+          <div class="feature-visual-card feature-speaker-card">
+            <span class="feature-visual-title">DMEA25</span>
+            <img src="Images/Andi_DMEA25.jpeg" alt="Andreas T. Bachmeier speaking at DMEA25">
+          </div>
+          <div class="feature-visual-card feature-speaker-card">
+            <span class="feature-visual-title">DMEA26</span>
+            <img src="Images/Andi_DMEA26.png" alt="Andreas T. Bachmeier speaking at DMEA26">
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Surface recent public speaking appearances in the existing Featured Content area so visitors can see examples of talks at a glance.
- Add a direct header navigation entry for easy access to the Featured Content section.
- Reduce header and logo footprint to accommodate the additional nav item and improve overall header proportions.

### Description
- Inserted a new Featured Content card titled "Examples of my appearances as public speaker." containing two visual cards for `DMEA25` and `DMEA26` that use `Images/Andi_DMEA25.jpeg` and `Images/Andi_DMEA26.png` respectively in `index.html`.
- Added a first-position header nav link to the Featured Content section (`#feature`) in `index.html`.
- Introduced CSS rules for speaker cards (`.feature-speaker`, `.feature-speaker-grid`, `.feature-speaker-card`, and `.feature-visual-title`) and grid sizing for two-column speaker presentation in `CSS/Styles.css`.
- Reduced header vertical padding and logo size across desktop/tablet/mobile breakpoints and tightened nav spacing/font size in `CSS/Styles.css` to make the header less tall and to preserve layout.

### Testing
- Parsed `index.html` with Python's `html.parser` to validate it is syntactically well-formed, which succeeded.
- Verified the two image files exist and reported their sizes using a short Python check, which succeeded for both `Images/Andi_DMEA25.jpeg` and `Images/Andi_DMEA26.png`.
- Launched a simple local server with `python3 -m http.server` and fetched `/index.html` to ensure the page is served (HTTP 200), which succeeded.
- Ran `git diff --check` for whitespace/errors, which returned no issues.
- Attempted `npx --yes playwright --version` to prepare a visual check, but the npm registry returned `403 Forbidden` in this environment and the Playwright check could not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdef3db34832d969967a423366831)